### PR TITLE
Fix long filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.2
+* Fix issue with long filenames
+
 ## 0.12.0
 * Bug fixes
 * Mark pending tabs

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expose",
   "main": "./lib/expose",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Quick tab overview of open files",
   "keywords": [
     "tab",

--- a/styles/expose.less
+++ b/styles/expose.less
@@ -48,7 +48,6 @@ atom-workspace-axis.expose-blur {
         cursor: move;
 
         .title {
-
           word-break: break-all;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/styles/expose.less
+++ b/styles/expose.less
@@ -48,7 +48,8 @@ atom-workspace-axis.expose-blur {
         cursor: move;
 
         .title {
-          white-space: nowrap;
+
+          word-break: break-all;
           overflow: hidden;
           text-overflow: ellipsis;
           margin: 0 15px;


### PR DESCRIPTION
There was my issue:
https://github.com/mrodalgaard/atom-expose/issues/21

At my project I have a long filenames, so many of them just stripped by this plugin and make it useless for me. This pull request fix this issue.

Before merge request it looks like this:
![before-merge request](https://cloud.githubusercontent.com/assets/3372058/16072226/d5752a16-32f0-11e6-8b35-600bf09450c5.png)

After merge request it looks like this:
![after-merge request](https://cloud.githubusercontent.com/assets/3372058/16072225/d574a28a-32f0-11e6-9e69-8d731f519af7.png)
