### PR TITLE
Ignoring Case in Search Box

### DIFF
--- a/lib/expose-view.coffee
+++ b/lib/expose-view.coffee
@@ -127,7 +127,7 @@ class ExposeView extends View
       for item in pane.getItems()
         exposeTabView = new ExposeTabView(item, color)
 
-        continue if exposeTabView.title.indexOf(searchText) is -1
+        continue if exposeTabView.title.toLowerCase().indexOf(searchText.toLowerCase()) is -1
 
         @tabs.push exposeTabView
         @tabList.append exposeTabView

--- a/spec/expose-tab-view-spec.coffee
+++ b/spec/expose-tab-view-spec.coffee
@@ -84,8 +84,8 @@ describe "ExposeTabView", ->
         runs ->
           exposeTabView = new ExposeTabView(item)
           expect(exposeTabView.title).toBe 'Markdown Preview'
-          expect(exposeTabView.tabBody.find('a')).toHaveLength 1
-          expect(exposeTabView.tabBody.find('a').attr('class')).toContain 'markdown'
+          expect(exposeTabView.tabBody.find('ar')).toHaveLength 1
+          expect(exposeTabView.tabBody.find('ar').attr('class')).toContain 'markdown'
 
     it "populates text editor with minimap activated", ->
       waitsForPromise ->


### PR DESCRIPTION
## Issue
* In use with the new search functionality I found that the case sensitivity interrupted my work flows compared to the `Symbol-View` package
  * With `ctrl/cmd+P ` the search field is case insensitive

## Changes Made
* Call `toLowerCase()` on search text and tab title to ignore case